### PR TITLE
New release

### DIFF
--- a/src/pages/ProjectBusiness.tsx
+++ b/src/pages/ProjectBusiness.tsx
@@ -300,6 +300,23 @@ const ProjectBusiness = () => {
     return () => clearInterval(interval);
   }, [projectId, isWaitingPayment]);
 
+  // Listen for project status updates (e.g., when payment is cancelled)
+  useEffect(() => {
+    const handleProjectStatusUpdate = (event: CustomEvent) => {
+      const { projectId: updatedProjectId, newStatus } = event.detail;
+      if (updatedProjectId === projectId) {
+        console.log('📡 Received projectStatusUpdated event, updating status to:', newStatus);
+        setProjectStatus(newStatus);
+      }
+    };
+
+    window.addEventListener('projectStatusUpdated', handleProjectStatusUpdate as EventListener);
+    
+    return () => {
+      window.removeEventListener('projectStatusUpdated', handleProjectStatusUpdate as EventListener);
+    };
+  }, [projectId]);
+
   if (loading) {
     return <div>Chargement...</div>; // Or a loading spinner component
   }


### PR DESCRIPTION
This pull request introduces enhancements to the payment cancellation flow and ensures the UI stays synchronized with project status updates. The most significant changes include adding logic to reset the project status to "free" when a payment is canceled and implementing an event listener to handle real-time updates to the project status in the UI.

### Enhancements to payment cancellation logic:

* [`src/hooks/useStripePayment.tsx`](diffhunk://#diff-8bebc604dca4bf6c889619f846acf7568cad81c631e01b30f30b069e2be62598L216-R251): Updated the `cancelPayment` function to reset the project status to "free" if the current status is in a "waiting" state (`pay_1_waiting` or `pay_2_waiting`). This includes error handling and dispatching a custom event (`projectStatusUpdated`) to notify the UI of the status change.

### Real-time UI synchronization:

* [`src/pages/ProjectBusiness.tsx`](diffhunk://#diff-fea146ad92633a5dd8c8980a39b003810ddbc6e0b053ce3edc2680c5b55f5811R303-R319): Added a `useEffect` hook to listen for the `projectStatusUpdated` custom event. When triggered, it updates the project status in the UI to reflect the new status.